### PR TITLE
Fix tensorflow-notebook image version

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,1 +1,1 @@
-docker run --rm --volume %cd%/notebooks:/home/jovyan/work --name deeplearning -p 8888:8888 jupyter/tensorflow-notebook:latest
+docker run --rm --volume %cd%/notebooks:/home/jovyan/work --name deeplearning -p 8888:8888 jupyter/tensorflow-notebook:7a3e968dd212

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sudo docker run --rm --volume $(pwd)/notebooks:/home/jovyan/work --name deeplearning -p 8888:8888 jupyter/tensorflow-notebook:latest
+sudo docker run --rm --volume $(pwd)/notebooks:/home/jovyan/work --name deeplearning -p 8888:8888 jupyter/tensorflow-notebook:7a3e968dd212

--- a/run_toolbox.bat
+++ b/run_toolbox.bat
@@ -1,2 +1,2 @@
 REM If above command doesn't work. Run this command:
-docker run --rm --volume //c/Users/<USER>/SummerSchool2019/notebooks://home/jovyan/work --name deeplearning -p 8888:8888 jupyter/tensorflow-notebook:latest 
+docker run --rm --volume //c/Users/<USER>/SummerSchool2019/notebooks://home/jovyan/work --name deeplearning -p 8888:8888 jupyter/tensorflow-notebook:7a3e968dd212 


### PR DESCRIPTION
In den run-Skripten wird stets die "latest"-Version des Containers benutzt. Mit der letzten Version funktionieren aber einige imports nicht mehr. (Kann direkt im HelloWorld-Notebook getestet werden.)